### PR TITLE
Implement Phase 1 master prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # k8s_simplify
 
 This project provides a framework for deploying and managing Kubernetes clusters on Linux.
-It follows a phase-based workflow described in `AGENTS.md` and includes placeholders for
-installation, update and rollback operations.
+It follows a phase-based workflow described in `AGENTS.md`.
+The first phase (master node preparation) is now implemented and automatically
+runs as part of the `install` command.
 
 ## Usage
 

--- a/src/k8s_simplify/cli.py
+++ b/src/k8s_simplify/cli.py
@@ -2,6 +2,8 @@ import argparse
 from dataclasses import dataclass, field
 from typing import List
 
+from .phase1 import Phase1Error, prepare_master
+
 
 @dataclass
 class ClusterConfig:
@@ -14,7 +16,11 @@ class ClusterConfig:
 
 def master_node_preparation(cfg: ClusterConfig):
     print(f"[Phase 1] Preparing master node {cfg.master_ip}")
-    # TODO: validate packages, disable swap, etc.
+    try:
+        prepare_master(cfg.master_ip, cfg.ssh_user, cfg.ssh_password)
+    except Phase1Error as exc:
+        print(exc)
+        raise SystemExit(1)
 
 
 def install_master(cfg: ClusterConfig):

--- a/src/k8s_simplify/phase1.py
+++ b/src/k8s_simplify/phase1.py
@@ -1,0 +1,105 @@
+"""Utilities for Phase 1: master node preparation."""
+
+from subprocess import CalledProcessError, run
+from typing import List
+
+
+class Phase1Error(Exception):
+    """Custom exception for phase 1 failures."""
+
+
+def _ssh_cmd(ip: str, user: str, password: str, command: str) -> List[str]:
+    base = ["ssh", "-o", "StrictHostKeyChecking=no", f"{user}@{ip}", command]
+    if password:
+        return ["sshpass", "-p", password] + base
+    return base
+
+
+def run_remote(ip: str, user: str, password: str, command: str) -> None:
+    """Run a command on a remote host via SSH."""
+    try:
+        run(_ssh_cmd(ip, user, password, command), check=True)
+    except CalledProcessError as exc:
+        raise Phase1Error(f"Command failed on {ip}: {command}") from exc
+
+
+def prepare_master(ip: str, user: str, password: str) -> None:
+    """Execute master node preparation steps."""
+    print("* Installing required packages on master")
+    run_remote(ip, user, password, "sudo apt-get update -y")
+    run_remote(
+        ip,
+        user,
+        password,
+        "sudo apt-get install -y containerd apt-transport-https curl gpg",
+    )
+
+    print("* Configuring containerd")
+    run_remote(ip, user, password, "sudo mkdir -p /etc/containerd")
+    run_remote(
+        ip,
+        user,
+        password,
+        "sudo sh -c 'containerd config default >/etc/containerd/config.toml'",
+    )
+    run_remote(ip, user, password, "sudo systemctl restart containerd")
+
+    print("* Installing kubeadm, kubelet and kubectl")
+    run_remote(
+        ip,
+        user,
+        password,
+        "curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key | "
+        "sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg",
+    )
+    run_remote(
+        ip,
+        user,
+        password,
+        "echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] "
+        "https://pkgs.k8s.io/core:/stable:/v1.33/deb/ /' | "
+        "sudo tee /etc/apt/sources.list.d/kubernetes.list",
+    )
+    run_remote(ip, user, password, "sudo apt-get update -y")
+    run_remote(
+        ip,
+        user,
+        password,
+        "sudo apt-get install -y kubelet kubeadm kubectl && "
+        "sudo apt-mark hold kubelet kubeadm kubectl",
+    )
+
+    print("* Disabling swap")
+    run_remote(ip, user, password, "sudo swapoff -a")
+    run_remote(
+        ip,
+        user,
+        password,
+        "sudo sed -i '/ swap / s/^/#/' /etc/fstab",
+    )
+
+    print("* Enabling IPv4 forwarding")
+    run_remote(ip, user, password, "sudo sysctl -w net.ipv4.ip_forward=1")
+    run_remote(
+        ip,
+        user,
+        password,
+        "grep -q '^net.ipv4.ip_forward=1' /etc/sysctl.conf || "
+        "echo 'net.ipv4.ip_forward=1' | sudo tee -a /etc/sysctl.conf",
+    )
+
+    print("* Creating k8sadmin user")
+    run_remote(
+        ip,
+        user,
+        password,
+        "id k8sadmin >/dev/null 2>&1 || sudo useradd -m -s /bin/bash k8sadmin",
+    )
+    run_remote(
+        ip,
+        user,
+        password,
+        "echo 'k8sadmin ALL=(ALL) NOPASSWD:ALL' | sudo tee /etc/sudoers.d/k8sadmin",
+    )
+    print("Master node preparation complete")
+


### PR DESCRIPTION
## Summary
- implement master node preparation utilities
- integrate phase 1 preparation in CLI
- mention phase 1 support in README

## Testing
- `PYTHONPATH=src python -m k8s_simplify --help`
- `PYTHONPATH=src python -m k8s_simplify install --name test --master 127.0.0.1` *(fails to SSH as expected)*
- `python -m py_compile src/k8s_simplify/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685a88bea260833399e434d0fa166d39