### PR TITLE
Implement phase 3 toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This project provides a framework for deploying and managing Kubernetes clusters on Linux.
 It follows a phase-based workflow described in `AGENTS.md`.
-Phases 1 and 2 (master preparation and installation) are implemented and run
-automatically as part of the `install` command.
+Phases 1-3 (master preparation, installation and verification) are implemented
+and run automatically as part of the `install` command.
 
 ## Usage
 

--- a/src/k8s_simplify/cli.py
+++ b/src/k8s_simplify/cli.py
@@ -4,6 +4,7 @@ from typing import List
 
 from .phase1 import Phase1Error, prepare_master
 from .phase2 import Phase2Error, init_master
+from .phase3 import Phase3Error, verify_master_node
 
 
 @dataclass
@@ -36,7 +37,11 @@ def install_master(cfg: ClusterConfig):
 
 def verify_master(cfg: ClusterConfig):
     print("[Phase 3] Verifying master node setup")
-    # TODO: check services and dashboard
+    try:
+        verify_master_node(cfg.master_ip, cfg.ssh_user, cfg.ssh_password)
+    except Phase3Error as exc:
+        print(exc)
+        raise SystemExit(1)
 
 
 def deploy_workers(cfg: ClusterConfig):

--- a/src/k8s_simplify/phase3.py
+++ b/src/k8s_simplify/phase3.py
@@ -1,0 +1,44 @@
+"""Utilities for Phase 3: master node verification."""
+
+from subprocess import CalledProcessError, run
+
+from .phase1 import _ssh_cmd
+
+
+class Phase3Error(Exception):
+    """Custom exception for phase 3 failures."""
+
+
+def run_remote_capture(ip: str, user: str, password: str, command: str) -> str:
+    """Run a remote command via SSH and return its output."""
+    cmd = _ssh_cmd(ip, user, password, command)
+    try:
+        result = run(cmd, check=True, capture_output=True, text=True)
+    except CalledProcessError as exc:
+        raise Phase3Error(f"Command failed on {ip}: {command}") from exc
+    return result.stdout.strip()
+
+
+def check_service_active(ip: str, user: str, password: str, service: str) -> None:
+    """Ensure a systemd service is active on the remote host."""
+    status = run_remote_capture(ip, user, password, f"systemctl is-active {service}")
+    if status != "active":
+        raise Phase3Error(f"Service {service} not active on {ip}")
+
+
+def verify_dashboard(ip: str, user: str, password: str) -> None:
+    """Verify the Kubernetes dashboard is reachable."""
+    run_remote_capture(ip, user, password, f"curl -ks https://{ip}:32443 >/dev/null")
+
+
+def verify_master_node(ip: str, user: str, password: str) -> None:
+    """Verify master node services and dashboard."""
+    print("* Checking container runtime")
+    check_service_active(ip, user, password, "containerd")
+    print("* Checking kubelet service")
+    check_service_active(ip, user, password, "kubelet")
+    print("* Checking kubectl connectivity")
+    run_remote_capture(ip, user, password, "kubectl get nodes")
+    print("* Checking dashboard access")
+    verify_dashboard(ip, user, password)
+    print("Master node verification successful")


### PR DESCRIPTION
## Summary
- implement Phase 3 verification as `phase3.py`
- call the new verifier from the CLI
- update README to state phases 1-3 are automated

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a8c25a2108333aa9c45acd6b850b7