### PR TITLE
Implement phase 5 node health checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This project provides a framework for deploying and managing Kubernetes clusters
 It follows a phase-based workflow described in `AGENTS.md`.
 Phases 1-4 (master preparation, installation, verification and worker
 deployment) are implemented and run automatically as part of the `install`
-command.
+command. Phase 5 performs a health check to ensure all nodes report `Ready`
+status after joining the cluster.
 
 ## Usage
 

--- a/src/k8s_simplify/cli.py
+++ b/src/k8s_simplify/cli.py
@@ -11,6 +11,7 @@ from .phase4 import (
     join_worker,
     prepare_worker,
 )
+from .phase5 import Phase5Error, check_node_health, list_nodes
 
 
 @dataclass
@@ -72,7 +73,14 @@ def deploy_workers(cfg: ClusterConfig):
 
 def check_nodes(cfg: ClusterConfig):
     print("[Phase 5] Checking node health")
-    # TODO: kubectl get nodes
+    try:
+        print("* Current node status:")
+        nodes = list_nodes(cfg.master_ip, cfg.ssh_user, cfg.ssh_password)
+        print(nodes)
+        check_node_health(cfg.master_ip, cfg.ssh_user, cfg.ssh_password)
+    except Phase5Error as exc:
+        print(exc)
+        raise SystemExit(1)
 
 
 def finalize_install(cfg: ClusterConfig):

--- a/src/k8s_simplify/phase5.py
+++ b/src/k8s_simplify/phase5.py
@@ -1,0 +1,31 @@
+"""Utilities for Phase 5: node health checks."""
+
+from .phase2 import run_remote_capture
+
+
+class Phase5Error(Exception):
+    """Custom exception for phase 5 failures."""
+
+
+def list_nodes(ip: str, user: str, password: str) -> str:
+    """Return the output of `kubectl get nodes` from the master node."""
+    try:
+        return run_remote_capture(ip, user, password, "kubectl get nodes --no-headers -o wide")
+    except Exception as exc:  # broad but fine for CLI tool
+        raise Phase5Error(f"Failed to retrieve node list from {ip}") from exc
+
+
+def check_node_health(ip: str, user: str, password: str) -> None:
+    """Validate that all nodes report Ready status."""
+    output = list_nodes(ip, user, password)
+    unhealthy = []
+    for line in output.splitlines():
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        name, status = parts[0], parts[1]
+        if status != "Ready":
+            unhealthy.append(f"{name} ({status})")
+    if unhealthy:
+        raise Phase5Error("Unhealthy nodes detected: " + ", ".join(unhealthy))
+


### PR DESCRIPTION
## Summary
- add a new `phase5` module for node health verification
- print node status and fail if any nodes are not `Ready`
- integrate the new phase into the CLI workflow
- document phase 5 in README

## Testing
- `PYTHONPATH=src python -m k8s_simplify -h`
- `PYTHONPATH=src python -m k8s_simplify install -h`


------
https://chatgpt.com/codex/tasks/task_e_685a8e3b257c833399ee20cc2ab4eb6a