### PR TITLE
Fix remote command errors and versioned upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ provide `sudo` access for the user supplied to the tool.
 
 Outbound internet access is required during installation because the scripts
 download Kubernetes manifests and packages. On hosts without access or with a
-different package manager, manual preparation may be required.
+different package manager, manual preparation may be required. The automation
+expects an apt-based system with passwordless `sudo` available for the chosen
+user; other environments may need manual adjustments.
 
 ## Limitations
 

--- a/src/k8s_simplify/phase1.py
+++ b/src/k8s_simplify/phase1.py
@@ -24,15 +24,19 @@ def run_remote(ip: str, user: str, password: str, command: str, retries: int = 2
     last_exc: Optional[CalledProcessError] = None
     for _ in range(retries + 1):
         try:
-            run(_ssh_cmd(ip, user, password, command), check=True)
+            run(
+                _ssh_cmd(ip, user, password, command),
+                check=True,
+                capture_output=True,
+                text=True,
+            )
             return
         except CalledProcessError as exc:
             last_exc = exc
-    stderr = ""
-    if last_exc and last_exc.stderr:
-        stderr = last_exc.stderr.decode("utf-8", "ignore")
+    stderr = last_exc.stderr or ""
+    stdout = last_exc.stdout or ""
     raise Phase1Error(
-        f"Command failed on {ip}: {command}\n{stderr}"
+        f"Command failed on {ip}: {command}\nSTDOUT: {stdout}\nSTDERR: {stderr}"
     ) from last_exc
 
 

--- a/src/k8s_simplify/phase2.py
+++ b/src/k8s_simplify/phase2.py
@@ -20,10 +20,10 @@ def run_remote_capture(ip: str, user: str, password: str, command: str, retries:
             return result.stdout.strip()
         except CalledProcessError as exc:
             last_exc = exc
-    stderr = ""
-    if last_exc and last_exc.stderr:
-        stderr = last_exc.stderr.decode("utf-8", "ignore")
-    raise Phase2Error(f"Command failed on {ip}: {command}\n{stderr}") from last_exc
+    stderr = last_exc.stderr if last_exc and last_exc.stderr else ""
+    raise Phase2Error(
+        f"Command failed on {ip}: {command}\n{stderr}"
+    ) from last_exc
 
 
 def init_master(ip: str, user: str, password: str) -> str:

--- a/src/k8s_simplify/phase3.py
+++ b/src/k8s_simplify/phase3.py
@@ -20,10 +20,10 @@ def run_remote_capture(ip: str, user: str, password: str, command: str, retries:
             return result.stdout.strip()
         except CalledProcessError as exc:
             last_exc = exc
-    stderr = ""
-    if last_exc and last_exc.stderr:
-        stderr = last_exc.stderr.decode("utf-8", "ignore")
-    raise Phase3Error(f"Command failed on {ip}: {command}\n{stderr}") from last_exc
+    stderr = last_exc.stderr if last_exc and last_exc.stderr else ""
+    raise Phase3Error(
+        f"Command failed on {ip}: {command}\n{stderr}"
+    ) from last_exc
 
 
 def check_service_active(ip: str, user: str, password: str, service: str) -> None:

--- a/src/k8s_simplify/update.py
+++ b/src/k8s_simplify/update.py
@@ -45,8 +45,21 @@ def update_master(ip: str, user: str, password: str, version: str) -> None:
 def update_worker(ip: str, user: str, password: str, version: str) -> None:
     """Upgrade Kubernetes components on a worker node."""
     try:
-        run_remote(ip, user, password, "sudo kubeadm upgrade node")
-        run_remote(ip, user, password, "sudo apt-get install -y kubelet kubeadm kubectl")
+        run_remote(
+            ip,
+            user,
+            password,
+            (
+                "sudo apt-get install -y "
+                f"kubelet={version} kubeadm={version} kubectl={version}"
+            ),
+        )
+        run_remote(
+            ip,
+            user,
+            password,
+            f"sudo kubeadm upgrade node --kubelet-version {version}",
+        )
         run_remote(ip, user, password, "sudo systemctl restart kubelet")
     except Exception as exc:
         raise UpdateError(f"Failed to update worker {ip}") from exc


### PR DESCRIPTION
## Summary
- show stdout/stderr when remote commands fail
- avoid decoding strings in phase2 and phase3 error handling
- use the provided Kubernetes version when upgrading workers
- document apt and sudo assumptions

## Testing
- `python -m compileall -q src/k8s_simplify`
- `PYTHONPATH=src python -m k8s_simplify.cli --help | head`

------
https://chatgpt.com/codex/tasks/task_e_685a9a039f2c83338c363bbe785c259c