### PR TITLE
Add master and node preflight scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ python -m k8s_simplify rollback --master 192.168.1.10 \
 
 The `suplement/` directory contains old helper scripts kept for reference only.
 
+## Preflight scripts
+
+Two shell scripts are provided to prepare hosts before running the automated
+installer:
+
+- `master_preflight.sh` – run on the machine that will become the control plane
+  node.
+- `node_preflight.sh` – run on each worker node.
+
+Both scripts must be executed as root. They install containerd and the
+Kubernetes packages, disable swap and enable IPv4 forwarding. After running the
+master script you can execute the `install` command from your management
+machine to provision the cluster.
+
 ## Requirements
 
 The CLI relies on `ssh` being installed locally. If you supply a password via

--- a/master_preflight.sh
+++ b/master_preflight.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run as root (e.g. with sudo)" >&2
+  exit 1
+fi
+
+echo "== Master node preflight =="
+
+apt-get update -y
+apt-get install -y containerd apt-transport-https curl gpg
+
+mkdir -p /etc/containerd
+if [ ! -f /etc/containerd/config.toml ]; then
+  containerd config default >/etc/containerd/config.toml
+fi
+systemctl restart containerd
+
+if [ ! -d /etc/apt/keyrings ]; then
+  mkdir -p -m 755 /etc/apt/keyrings
+fi
+if [ ! -f /etc/apt/keyrings/kubernetes-apt-keyring.gpg ]; then
+  curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key \
+    | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+fi
+cat <<'REPO' >/etc/apt/sources.list.d/kubernetes.list
+deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.33/deb/ /
+REPO
+apt-get update -y
+apt-get install -y kubelet kubeadm kubectl
+apt-mark hold kubelet kubeadm kubectl
+
+swapoff -a
+sed -i '/ swap / s/^/#/' /etc/fstab
+
+sysctl -w net.ipv4.ip_forward=1
+if ! grep -q '^net.ipv4.ip_forward=1' /etc/sysctl.conf; then
+  echo 'net.ipv4.ip_forward=1' >> /etc/sysctl.conf
+fi
+
+if ! id k8sadmin >/dev/null 2>&1; then
+  useradd -m -s /bin/bash k8sadmin
+fi
+echo 'k8sadmin ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/k8sadmin
+
+cat <<'EOM'
+Preflight complete.
+Next steps:
+  1. Run the installer from your management machine:
+     python -m k8s_simplify install --name <cluster> --master <this_ip> --user k8sadmin
+  2. Run the node_preflight.sh script on each worker node before installation.
+EOM

--- a/node_preflight.sh
+++ b/node_preflight.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -e
+
+if [ "$EUID" -ne 0 ]; then
+  echo "Please run as root (e.g. with sudo)" >&2
+  exit 1
+fi
+
+echo "== Worker node preflight =="
+
+apt-get update -y
+apt-get install -y containerd apt-transport-https curl gpg
+
+mkdir -p /etc/containerd
+if [ ! -f /etc/containerd/config.toml ]; then
+  containerd config default >/etc/containerd/config.toml
+fi
+systemctl restart containerd
+
+if [ ! -d /etc/apt/keyrings ]; then
+  mkdir -p -m 755 /etc/apt/keyrings
+fi
+if [ ! -f /etc/apt/keyrings/kubernetes-apt-keyring.gpg ]; then
+  curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key \
+    | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+fi
+cat <<'REPO' >/etc/apt/sources.list.d/kubernetes.list
+deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.33/deb/ /
+REPO
+apt-get update -y
+apt-get install -y kubelet kubeadm kubectl
+apt-mark hold kubelet kubeadm kubectl
+
+swapoff -a
+sed -i '/ swap / s/^/#/' /etc/fstab
+
+sysctl -w net.ipv4.ip_forward=1
+if ! grep -q '^net.ipv4.ip_forward=1' /etc/sysctl.conf; then
+  echo 'net.ipv4.ip_forward=1' >> /etc/sysctl.conf
+fi
+
+cat <<'EOM'
+Preflight complete.
+Run the master preflight script on the control plane node and then execute the installer from your management machine.
+EOM


### PR DESCRIPTION
## Summary
- add `master_preflight.sh` and `node_preflight.sh` for preparing hosts
- document usage of the preflight scripts in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685a9b967e2083338290cd8e958ad4ac