### PR TITLE
Handle invoking user in preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ installer:
 - `node_preflight.sh` – run on each worker node.
 
 Both scripts must be executed as root. They install containerd and the
-Kubernetes packages, disable swap and enable IPv4 forwarding. After running the
-master script you can execute the `install` command from your management
-machine to provision the cluster.
+Kubernetes packages, disable swap and enable IPv4 forwarding. When invoked via
+`sudo`, the scripts also grant passwordless sudo rights to the user that ran the
+command, ensuring that the Python installer can operate without prompting for a
+password. After running the master script you can execute the `install` command
+from your management machine to provision the cluster.
 
 ## Requirements
 

--- a/master_preflight.sh
+++ b/master_preflight.sh
@@ -8,6 +8,11 @@ fi
 
 echo "== Master node preflight =="
 
+# Grant passwordless sudo to the user that invoked this script via sudo
+if [ -n "$SUDO_USER" ] && [ "$SUDO_USER" != "root" ]; then
+  echo "$SUDO_USER ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/$SUDO_USER
+fi
+
 apt-get update -y
 apt-get install -y containerd apt-transport-https curl gpg
 

--- a/node_preflight.sh
+++ b/node_preflight.sh
@@ -8,6 +8,11 @@ fi
 
 echo "== Worker node preflight =="
 
+# Grant passwordless sudo to the user that invoked this script via sudo
+if [ -n "$SUDO_USER" ] && [ "$SUDO_USER" != "root" ]; then
+  echo "$SUDO_USER ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/$SUDO_USER
+fi
+
 apt-get update -y
 apt-get install -y containerd apt-transport-https curl gpg
 


### PR DESCRIPTION
## Summary
- grant passwordless sudo to the user who invokes the preflight scripts
- document how sudo invocation configures the current user

## Testing
- `python3 -m py_compile src/k8s_simplify/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685a9f21e2488333abaf1bb3d43f35db