### PR TITLE
Fix gpg batch mode

### DIFF
--- a/master_preflight.sh
+++ b/master_preflight.sh
@@ -34,7 +34,7 @@ if [ ! -d /etc/apt/keyrings ]; then
 fi
 if [ ! -f /etc/apt/keyrings/kubernetes-apt-keyring.gpg ]; then
   curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key \
-    | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+    | gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 fi
 cat <<'REPO' >/etc/apt/sources.list.d/kubernetes.list
 deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.33/deb/ /

--- a/node_preflight.sh
+++ b/node_preflight.sh
@@ -34,7 +34,7 @@ if [ ! -d /etc/apt/keyrings ]; then
 fi
 if [ ! -f /etc/apt/keyrings/kubernetes-apt-keyring.gpg ]; then
   curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key \
-    | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+    | gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 fi
 cat <<'REPO' >/etc/apt/sources.list.d/kubernetes.list
 deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.33/deb/ /

--- a/src/k8s_simplify/phase1.py
+++ b/src/k8s_simplify/phase1.py
@@ -67,7 +67,7 @@ def prepare_master(ip: str, user: str, password: str) -> None:
         user,
         password,
         "curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key | "
-        "sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg",
+        "sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg",
     )
     run_remote(
         ip,

--- a/src/k8s_simplify/phase4.py
+++ b/src/k8s_simplify/phase4.py
@@ -33,7 +33,7 @@ def prepare_worker(ip: str, user: str, password: str) -> None:
         "sudo systemctl restart containerd",
         (
             "curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key | "
-            "sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg"
+            "sudo gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg"
         ),
         (
             "echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] "

--- a/suplement/install.sh
+++ b/suplement/install.sh
@@ -64,7 +64,7 @@ install_prereqs() {
       mkdir -p -m 755 /etc/apt/keyrings
     fi
     curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key \
-      | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+      | gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
     cat <<'REPO' >/etc/apt/sources.list.d/kubernetes.list
 deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.33/deb/ /
 REPO
@@ -142,7 +142,7 @@ install_prereqs() {
       mkdir -p -m 755 /etc/apt/keyrings
     fi
     curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.33/deb/Release.key \
-      | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+      | gpg --batch --yes --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
     cat <<'REPO' >/etc/apt/sources.list.d/kubernetes.list
 deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.33/deb/ /
 REPO


### PR DESCRIPTION
## Summary
- allow non-interactive gpg usage during key import

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `shellcheck master_preflight.sh node_preflight.sh suplement/install.sh`

------
https://chatgpt.com/codex/tasks/task_e_685aa45015848333ad27f1f940bb5974